### PR TITLE
Fix GitHub capitalization in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This plugin is in no way endorsed by Udemy in any way.
 
 ## Support
 
-For support and further information, please visit [Github](https://github.com/tylerkeithullery/udemyapiwp).
+For support and further information, please visit [GitHub](https://github.com/tylerkeithullery/udemyapiwp).
 
 ## Contributing
 

--- a/udemy-ai-for-wp/readme.txt
+++ b/udemy-ai-for-wp/readme.txt
@@ -73,7 +73,7 @@ This plugin is in no way endorsed by Udemy in any way.
 
 ## Support
 
-For support and further information, please visit [Github](https://github.com/tylerkeithullery/udemyapiwp).
+For support and further information, please visit [GitHub](https://github.com/tylerkeithullery/udemyapiwp).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- fix GitHub capitalization in README and plugin readme

## Testing
- `grep -n "GitHub" README.md`
- `grep -n "GitHub" udemy-ai-for-wp/readme.txt`

------
https://chatgpt.com/codex/tasks/task_e_68733c0c4aa4832da14e3df03bf08f29