### PR TITLE
Fix deactivation cleanup and cache handling

### DIFF
--- a/udemy-ai-for-wp/on_deactivate.php
+++ b/udemy-ai-for-wp/on_deactivate.php
@@ -39,7 +39,7 @@ function uci_delete_custom_table() {
         error_log('uci_delete_custom_table function triggered');
     }
     global $wpdb;
-    $table_name = $wpdb->prefix . 'uci_courses';
+    $table_name = $wpdb->prefix . 'udemy_courses';
     $result = $wpdb->query("DROP TABLE IF EXISTS `{$table_name}`");
     if ($result !== false) {
         error_log("Table {$table_name} deleted");
@@ -54,9 +54,9 @@ function uci_delete_secret_token() {
     if (function_exists('error_log')) {
         error_log('uci_delete_secret_token function triggered');
     }
-    if (delete_option('uci_secret_token')) {
-        error_log('uci_secret_token deleted');
+    if (delete_option('udemy_secret_token')) {
+        error_log('udemy_secret_token deleted');
     } else {
-        error_log('uci_secret_token not found');
+        error_log('udemy_secret_token not found');
     }
 }

--- a/udemy-ai-for-wp/udemy-ai-for-wp.php
+++ b/udemy-ai-for-wp/udemy-ai-for-wp.php
@@ -235,8 +235,8 @@ function uci_update_table() {
                 ));
             }
 
-            // Clear cache after updating the table
-            wp_cache_delete('uci_courses_' . $orderby . '_' . $order);
+            // Clear cached course data after updating
+            wp_cache_flush();
             wp_cache_delete('uci_last_updated');
 
             update_option('udemy_manual_update', $current_time);


### PR DESCRIPTION
## Summary
- correct table and option names when cleaning up on plugin deactivation
- flush the cache after updating courses

## Testing
- `php -l udemy-ai-for-wp/on_deactivate.php`
- `php -l udemy-ai-for-wp/udemy-ai-for-wp.php`

------
https://chatgpt.com/codex/tasks/task_e_68733a9a7f7c832d93f9f3ac31d6b4bf